### PR TITLE
fix: memory leak in SSR

### DIFF
--- a/packages/intly-react/src/index.tsx
+++ b/packages/intly-react/src/index.tsx
@@ -5,18 +5,26 @@ export interface Props {
   children: React.ReactNode;
 }
 
-export function createIntlyHandler<T extends AbstractDictionary>(intly: Intly<T>) {
-  return class IntlyHandler extends React.PureComponent<Props> {
-    public constructor(props: Props) {
-      super(props);
+// NOTE: this declaration is needed to avoid typescript's compile error (TS4094)
+// https://github.com/microsoft/TypeScript/issues/30355
+class IntlyHandler extends React.PureComponent<Props> {}
 
-      intly.on('languageChanged', () => {
-        this.forceUpdate();
-      });
+export function createIntlyHandler<T extends AbstractDictionary>(intly: Intly<T>): typeof IntlyHandler {
+  return class extends IntlyHandler {
+    public componentDidMount() {
+      intly.on('languageChanged', this.handleLanguageChanged);
+    }
+
+    public componentWillUnmount() {
+      intly.off('languageChanged', this.handleLanguageChanged);
     }
 
     public render() {
       return <React.Fragment key={intly.getLanguage()}>{this.props.children}</React.Fragment>;
+    }
+
+    private handleLanguageChanged = () => {
+      this.forceUpdate();
     }
   };
 }


### PR DESCRIPTION
This PR fixes a memory leak behavior in SSR.
`IntlyHandler` generates a closure to handle `languageChanged` event in its constructor with `this` capturing.
This causes memory leaks in a situation `IntlyHandler` is instantiated repeatedly like SSR.

here's our project's heap used plot:
![image](https://user-images.githubusercontent.com/6854255/72031820-f39d9a80-32d0-11ea-8a3d-f105e1347e20.png)

